### PR TITLE
Updated middleware

### DIFF
--- a/src/middleware/middleware.c
+++ b/src/middleware/middleware.c
@@ -36,6 +36,22 @@ uint8_t middleware_get_leds(void) {
     return (0x0f & read_data[0]);
 }
 
+void middleware_userlogic_enable(void)
+{
+    uint8_t addr_arr[1];
+    addr_arr[0] = 0x00; // set user_logic_reset to 0 => enable
+
+    qxi_write_blocking(ADDR_USER_LOGIC_RESET, addr_arr, 1);
+}
+
+void middleware_userlogic_disable(void)
+{
+    uint8_t addr_arr[1];
+    addr_arr[0] = 0x01; // keep reseting the userlogic
+
+    qxi_write_blocking(ADDR_USER_LOGIC_RESET, addr_arr, 1);
+}
+
 uint8_t middleware_get_design_id(void) {
     uint8_t read_data[1];
 

--- a/src/middleware/middleware.c
+++ b/src/middleware/middleware.c
@@ -3,6 +3,7 @@
 #include "middleware.h"
 #include "qxi.h"
 #include <stdint.h>
+#include <stdbool.h>
 
 void middleware_init() {
     qxi_init();
@@ -66,4 +67,8 @@ void middleware_write_blocking(uint32_t address, uint8_t *data, uint16_t len) {
 
 uint8_t middleware_read_blocking(uint32_t address, uint8_t *data, uint16_t len) {
     qxi_read_blocking(ADDR_USER_LOGIC_OFFSET + address, data, len);
+}
+
+bool middleware_userlogic_get_busy_status(void) {
+    return false;
 }

--- a/src/middleware/middleware.h
+++ b/src/middleware/middleware.h
@@ -4,8 +4,9 @@
 #include "qxi.h"
 #include <stdint.h>
 
-#define ADDR_MULTI_BOOT 0x0005
 #define ADDR_LEDS 0x0003
+#define ADDR_USER_LOGIC_RESET 0x04
+#define ADDR_MULTI_BOOT 0x0005
 #define ADDR_DESIGN_ID 2256
 #define ADDR_USER_LOGIC_OFFSET 0x0100
 
@@ -14,6 +15,8 @@ void middleware_deinit();
 void middleware_configure_fpga(uint32_t address);
 void middleware_set_fpga_leds(uint8_t leds);
 uint8_t middleware_get_leds(void);
+void middleware_userlogic_enable(void);
+void middleware_userlogic_disable(void);
 uint8_t middleware_get_design_id(void);
 void middleware_write_blocking(uint32_t address, uint8_t *data, uint16_t len);
 uint8_t middleware_read_blocking(uint32_t address, uint8_t *data, uint16_t len);

--- a/src/middleware/middleware.h
+++ b/src/middleware/middleware.h
@@ -3,6 +3,7 @@
 
 #include "qxi.h"
 #include <stdint.h>
+#include <stdbool.h>
 
 #define ADDR_LEDS 0x0003
 #define ADDR_USER_LOGIC_RESET 0x04
@@ -20,5 +21,6 @@ void middleware_userlogic_disable(void);
 uint8_t middleware_get_design_id(void);
 void middleware_write_blocking(uint32_t address, uint8_t *data, uint16_t len);
 uint8_t middleware_read_blocking(uint32_t address, uint8_t *data, uint16_t len);
+bool middleware_userlogic_get_busy_status(void);
 
 #endif // MY_PROJECT_MIDDLEWARE_H


### PR DESCRIPTION
I just did some minor additions to the middleware.h and .c files to make it compatible with the stub generator. Note that middleware.c includes a function bool middleware_userlogic_get_busy_status(void); that is currently not implemented correctly - it always returns false. Contact Chao to help fix this. 