### PR TITLE
Update run_checks.yml

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Lint Commits
         uses: wagoid/commitlint-github-action@v6
         with:
-          failOnWarnings: true
-          failOnErrors: true
+          failOnWarnings: false
+          failOnErrors: false
 
   clang-format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
chore: don't let commitlint action fail on errors