### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+
+## default owners, will receive review requests for anything
+* @DavidFederl
+
+## request review for any c code changes
+*.c @glencoe


### PR DESCRIPTION
Declaring code owners allows us
to automatically receive pr review
requests based on code ownership.