### PR TITLE
fix(hardware-test): replace old flash values

### DIFF
--- a/test/hardware/TestStub/HardwareTestStub.c
+++ b/test/hardware/TestStub/HardwareTestStub.c
@@ -15,9 +15,6 @@
 
 #define SOURCE_FILE "HWTEST-STUB"
 
-#define FLASH_BYTES_PER_PAGE 512
-#define FLASH_BYTES_PER_SECTOR 262144
-
 #include "Common.h"
 #include "EnV5HwConfiguration.h"
 #include "EnV5HwController.h"
@@ -119,8 +116,10 @@ _Noreturn void runTest(void) {
             PRINT("FPGA powered OFF");
             break;
         case 'd':
-            PRINT("Deploy: %s",
-                  modelDeploy(3 * FLASH_BYTES_PER_SECTOR, acceloratorId) ? "successful" : "failed");
+            PRINT("Sector bytes: %i", flashGetBytesPerSector(&flashConfig));
+            PRINT("Deploy: %s", modelDeploy(3 * flashGetBytesPerSector(&flashConfig), acceloratorId)
+                                    ? "successful"
+                                    : "failed");
             break;
         default:
             PRINT("Waiting ...");


### PR DESCRIPTION
Problem:
- This hardwaretest still used the hard coded values to define flash attributes

Solution:
- remove FLASH_BYTES_PER_SECTOR and FLASH_BYTES_PER_PAGE
- inside flashInit these values are already set using CFI
- replace usage of hard coded values with function calls 
  flashGetBytesPerSector and flashGetBytesPerPage