### PR TITLE
chore(devenv): add devenv support

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -18,6 +18,7 @@ module.exports = {
                    2, "always",
                    [
                      'github',
+                     'devenv',
                      'usb-protocol',
                      'hal',
                      'sensor',

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/82c0147677e510b247d8b9165c54f73d32dfd899/direnvrc" "sha256-7u4iDd1nZpxL4tCzmPG0dQgC5V+/44Ba+tHkPob1v2k="
+
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ NetworkConfig.c
 picotool/picotool*/
 
 ### IDE/Environment
-.envrc
 .idea/
 .vimrc
 .tool-versions
@@ -126,3 +125,9 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 build/
+
+
+### devenv
+.devenv/
+.devenv.flake.nix
+.direnv/

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,119 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1749054588,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "b6be42d9e6f6053be1d180e4a4fb95e0aa9a8424",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1747372754,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746807397,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "c5208b594838ea8e6cca5997fbf784b7cca1ca90",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1748856973,
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,44 @@
+{ pkgs, lib, config, inputs, ... }:
+
+let
+  unstablePkgs = import inputs.nixpkgs-unstable { system = pkgs.stdenv.system; };
+in
+{
+
+  packages = let
+    u = unstablePkgs;
+   in
+    [
+        pkgs.cmake
+        pkgs.ninja
+        pkgs.clang-tools
+        u.gcc-arm-embedded-13
+        u.ruff
+        u.mypy
+        u.picotool
+    ];
+
+
+  languages.c.enable = true;
+  languages.python = {
+    enable = true;
+    package = unstablePkgs.python312;
+    uv.enable = true;
+    uv.package = unstablePkgs.uv;
+  };
+
+  scripts.hello.exec = ''
+    echo hello from $GREET
+  '';
+
+  scripts.run_tests.exec = ''
+    cmake --build --preset unit_test
+    ctest --preset unit_test
+  '';
+
+  enterShell = ''
+    hello
+    cmake --version
+  '';
+
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  nixpkgs-unstable:
+    url: github:nixos/nixpkgs/nixpkgs-unstable
+
+# If you're using non-OSS software, you can set allowUnfree to true.
+# allowUnfree: true
+
+# If you're willing to use a package that's vulnerable
+# permittedInsecurePackages:
+#  - "openssl-1.1.1w"
+
+# If you have more than one devenv you can merge them
+#imports:
+# - ./backend


### PR DESCRIPTION
Introduces support for devenv (https://devenv.sh)
Devs can use that tool to bootstrap a full
dev environment including most necessary tools.
IDEs are not included atm.