### PR TITLE
fix(sensor): change Measurement Functions

### DIFF
--- a/src/sensor/adxl345b/Adxl345bInternal.h
+++ b/src/sensor/adxl345b/Adxl345bInternal.h
@@ -145,40 +145,39 @@ static void adxl345bInternalCalculateOffsetRegisterScaleFactors(float *xyOffsetS
  * the start of a new read
  *
  * @param sensor[in] configuration for sensor to use
- * @param dataResponseBuffer[out] memory where data received from the sensor is stored. needs to
- * be at least 6 bytes
+ * @param rawSamples[out] memory where data received from the sensor is stored
  * @return return the error code (0 if everything passed)
  *
  * @note read only, raw data needs to be converted into g-values
  */
 static adxl345bErrorCode_t adxl345bReadDataXYZ(adxl345bSensorConfiguration_t sensor,
-                                               uint8_t *dataResponseBuffer);
+                                               adxl345bRawData_t *rawSamples);
 
 /*! @brief
  * @IMPORTANT   We highly recommend using the "enV5_hw_configuration_rev_[x]" -library
  * @param sensor[in] configuration for sensor to use
- * @param dataResponseBuffer[out] memory where data received from the sensor is stored. needs to
- * be at least 6 bytes
+ * @param dataResponseBuffer[out] memory where data received from the sensor is stored.
  * @param maxFifoRead maximal Data you want to fetch from Fifo
  * @return return the error code (0 if everything passed)
  */
 static adxl345bErrorCode_t fetchDataFromFifo(adxl345bSensorConfiguration_t sensor,
-                                             uint8_t *dataResponseBuffer, uint8_t maxFifoRead);
+                                             adxl345bRawData_t *dataResponseBuffer,
+                                             uint8_t maxFifoRead);
 
 /*! @brief
  * @IMPORTANT   We highly recommend using the "enV5_hw_configuration_rev_[x]" -library
  * @param sensor[in] configuration for sensor to use
- * @param sizeOfBuffer[in] modulo 6 needs to be 0
- * @param remainder[in] modulo 6 needs to be 0
- * @param maxFifoRead[in] maximal Data you want to fetch from Fifo
- * @param buffer[out] memory where data received from the sensor is stored
+ * @param sizeOfBuffer[in]
+ * @param remainder[in]
+ * @param maxFifoRead[in] maximal amount of samples you want to fetch from Fifo
+ * @param buffer[out] memory where samples received from the sensor is stored
  * @param fifoInformation[in] Infomation which is stored in ADXL345B_FIFO_CONTROL
  * @return return the error code (0 if everything passed)
  */
 static adxl345bErrorCode_t manageFifoDataRead(adxl345bSensorConfiguration_t sensor,
-                                              int64_t sizeOfBuffer, uint8_t remainder,
-                                              uint8_t maxFifoRead, uint8_t *buffer,
-                                              uint8_t fifoInformation);
+                                              uint8_t fifoInformation, uint8_t maxFifoRead,
+                                              uint8_t remainder, adxl345bRawData_t *buffer,
+                                              int64_t sizeOfBuffer);
 
 /*!
  * @brief disables selftest force by setting selftest bit to 0 in the
@@ -189,6 +188,7 @@ static adxl345bErrorCode_t manageFifoDataRead(adxl345bSensorConfiguration_t sens
 
  * @return return the error code (0 if everything passed)
  */
+
 static adxl345bErrorCode_t
 adxl345bInternalDisableSelftestForce(adxl345bSensorConfiguration_t sensor);
 

--- a/src/sensor/adxl345b/include/eai/sensor/Adxl345b.h
+++ b/src/sensor/adxl345b/include/eai/sensor/Adxl345b.h
@@ -18,7 +18,6 @@
  *    - function has to be called before use of the sensor can be used \n
  *    needs max 1.5ms for idle state after power up
  * @IMPORTANT We highly recommend using the "enV5_hw_configuration_rev_[x]" -library
- *    -
  *
  * @param sensor[in] configuration for sensor to use
  *
@@ -52,8 +51,8 @@ adxl345bErrorCode_t adxl345bWriteConfigurationToSensor(adxl345bSensorConfigurati
  * @param samplesForTrigger number of samples to store before trigger acts (max 32)
  * @return return the error code (0 if everything passed)
  *
- * @note changing FIFOMode sets the number of samples in FIFO_CONTROL to 0.
- * Placing the device into bypass mode clears FIFO
+ * @note In trigger mode undesirable operation may occur if the value of the samples bits is 0.
+ * Placing the device into bypass mode clears FIFO.
  * max samplesForFIFOTrigger 32 -> you can read 33 Samples: fifo+(x/y/z)-register
  */
 adxl345bErrorCode_t adxl345bSetFIFOMode(adxl345bSensorConfiguration_t sensor, uint8_t fifoMode,
@@ -70,7 +69,8 @@ adxl345bErrorCode_t adxl345bSetFIFOMode(adxl345bSensorConfiguration_t sensor, ui
  *
  */
 adxl345bErrorCode_t adxl345bConvertDataXYZ(adxl345bSensorConfiguration_t sensor, float *xAxis,
-                                           float *yAxis, float *zAxis, uint8_t *responseBuffer);
+                                           float *yAxis, float *zAxis,
+                                           const adxl345bRawData_t rawSample);
 
 /*!
  * @brief changes the measurement range of the sensor
@@ -101,13 +101,12 @@ adxl345bErrorCode_t adxl345bReadSerialNumber(adxl345bSensorConfiguration_t senso
  * @IMPORTANT We highly recommend using the "enV5_hw_configuration_rev_[x]" -library
  *
  * @param sensor[in] configuration for sensor to use
- * @param rawData[out] raw data received from the xAxis,yAxis,zAxis. Needs to be at least 6 bytes.
- * (2 bytes each Axis)
+ * @param rawSamples[out] raw data received from sensor
  *
  * @return                       return the error code (0 if everything passed)
  */
 adxl345bErrorCode_t adxl345bGetSingleMeasurement(adxl345bSensorConfiguration_t sensor,
-                                                 uint8_t *rawData);
+                                                 adxl345bRawData_t *rawSamples);
 
 /*!
  * @brief reads requested number of raw data from the sensor in stream-, trigger- or fifo-mode
@@ -115,32 +114,32 @@ adxl345bErrorCode_t adxl345bGetSingleMeasurement(adxl345bSensorConfiguration_t s
  * @IMPORTANT We highly recommend using the "enV5_hw_configuration_rev_[x]" -library
  *
  * @param sensor[in] configuration for sensor to use
- * @param rawData[out] raw data array received from the xAxis,yAxis,zAxis. Each raw data needs to be
- * at least 6 bytes. (2 bytes each Axis)
- * @param sizeOfRawData[in] number of required Data
+ * @param rawSamples[out] raw samples array received from the sensor
+ * @param sizeOfRawSamples[in] number of required samples
  * @return return the error code (0 if everything passed)
  */
+
 adxl345bErrorCode_t adxl345bGetMultipleMeasurements(adxl345bSensorConfiguration_t sensor,
-                                                    uint8_t *rawData, uint32_t sizeOfRawData);
+                                                    adxl345bRawData_t *rawSamples,
+                                                    uint32_t sizeOfRawSamples);
 
 /*!
- * @brief reads raw data from the sensor. limited by milliseconds or given buffer for rawData
+ * @brief reads raw data from the sensor. limited by microseconds
  *
  * @IMPORTANT   - We highly recommend using the "enV5_hw_configuration_rev_[x]" -library
  * @IMPORTANT   - Can be interrupted.caller needs to ensure free rtos
  *
  * @param sensor[in] configuration for sensor to use
- * @param rawData[out] raw data array received from the xAxis,yAxis,zAxis. Each raw data needs to be
- * at least 6 bytes. (2 bytes each Axis)
- * @param milliseconds[in] measuring-time in milliseconds
- * @param sizeOfRawData[in/out] maximum size of rawData which is manipulated to return actual size
- * of read rawData
+ * @param durationInMicroseconds[in] measuring-time in micoseconds
+ * @param rawSamples[out] raw data array received from sensor
+ * @param sizeOfRawSamples[in] size of rawSample
  * @return return the error code (0 if everything passed)
  */
-adxl345bErrorCode_t adxl345bGetMeasurementsForNMilliseconds(adxl345bSensorConfiguration_t sensor,
-                                                            uint8_t *rawData, uint32_t milliseconds,
-                                                            uint32_t *sizeOfRawData);
 
+adxl345bErrorCode_t adxl345bGetMeasurementsForNMicroseconds(adxl345bSensorConfiguration_t sensor,
+                                                            uint32_t durationInMicroseconds,
+                                                            adxl345bRawData_t *rawSamples,
+                                                            uint32_t sizeOfRawSamples);
 /*!
  * @brief trigger the execution of the self-test procedure
  *

--- a/src/sensor/adxl345b/include/eai/sensor/Adxl345bTypedefs.h
+++ b/src/sensor/adxl345b/include/eai/sensor/Adxl345bTypedefs.h
@@ -11,7 +11,6 @@ typedef struct i2c_inst i2c_inst_t;
  * LPM for Low Power Mode.
  */
 enum {
-
     //!  represents LPM_BW_RATE 12.5
     ADXL345B_BW_RATE_LPM_12_point_5 = 0b00010111,
     ADXL345B_BW_RATE_LPM_25 = 0b00011000,
@@ -129,6 +128,20 @@ typedef struct adxl345bSensorConfiguration {
     i2c_inst_t *i2c_host;
     adxl345bI2cAddress_t i2c_slave_address;
 } adxl345bSensorConfiguration_t;
+
+typedef struct adxl345bDataRegisters {
+    uint8_t xZero;
+    uint8_t xOne;
+    uint8_t yZero;
+    uint8_t yOne;
+    uint8_t zZero;
+    uint8_t zOne;
+} adxl345bDataRegisters_t;
+
+typedef union adxl345bRawData {
+    adxl345bDataRegisters_t dataRegisters;
+    uint8_t data[sizeof(adxl345bDataRegisters_t)];
+} adxl345bRawData_t;
 
 typedef enum adxl345bRange {
     ADXL345B_2G_RANGE,

--- a/test/unit/UnitTestAdxl345b.c
+++ b/test/unit/UnitTestAdxl345b.c
@@ -1,7 +1,8 @@
 #include "I2cUnitTest.h"
 #include "eai/sensor/Adxl345b.h"
+#include "eai/sensor/Adxl345bTypedefs.h"
 #include <memory.h>
-#include <stdint.h>
+#include <stdlib.h>
 #include <unity.h>
 
 /*! JUST HERE TO SATISFY THE COMPILER
@@ -11,20 +12,16 @@
 
 adxl345bSensorConfiguration_t sensor;
 uint32_t numberOfSamples;
-uint8_t sizeOfSingleRawData;
 uint8_t serialNumber;
-uint32_t milliseconds;
+uint32_t microseconds;
 
 void setUp(void) {
     /* Default: Point to Pass */
     i2cUnittestWriteCommand = i2cUnittestWriteCommandPassForAdxl345b;
     i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInBypassMode;
 
-    adxl345bChangeMeasurementRange(sensor, ADXL345B_2G_RANGE);
-
-    numberOfSamples = 2;
-    sizeOfSingleRawData = 6;
-    milliseconds = 1;
+    numberOfSamples = 10;
+    microseconds = 1;
 }
 
 void tearDown(void) {}
@@ -35,33 +32,33 @@ void adxl345bReadSerialNumberGetSendCommandFail_errorIfHardwarFails(void) {
     i2cUnittestWriteCommand = i2cUnittestWriteCommandHardwareDefect;
 
     adxl345bErrorCode_t errorCode = adxl345bReadSerialNumber(sensor, &serialNumber);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
 }
 
 void adxl345bReadSerialNumberGetSendCommandFail_errorIfAckMissing(void) {
     i2cUnittestWriteCommand = i2cUnittestWriteCommandAckMissing;
 
     adxl345bErrorCode_t errorCode = adxl345bReadSerialNumber(sensor, &serialNumber);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
 }
 
 void adxl345bReadSerialNumberGetReceiveDataFail_errorIfHardwarFails(void) {
     i2cUnittestReadCommand = i2cUnittestReadCommandHardwareDefect;
 
     adxl345bErrorCode_t errorCode = adxl345bReadSerialNumber(sensor, &serialNumber);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
 }
 
 void adxl345bReadSerialNumberGetReceiveDataFail_errorIfAckMissing(void) {
     i2cUnittestReadCommand = i2cUnittestReadCommandAckMissing;
 
     adxl345bErrorCode_t errorCode = adxl345bReadSerialNumber(sensor, &serialNumber);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
 }
 
 void adxl345bReadSerialNumberReadSuccessful(void) {
-    uint8_t err = adxl345bReadSerialNumber(sensor, &serialNumber);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_NO_ERROR, err);
+    adxl345bErrorCode_t errorCode = adxl345bReadSerialNumber(sensor, &serialNumber);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_NO_ERROR, errorCode);
 }
 
 void adxl345bReadSerialNumberReadCorrectValue(void) {
@@ -76,642 +73,386 @@ void adxl345bReadSerialNumberReadCorrectValue(void) {
 
 /* endregion adxl345bReadSerialNumber */
 
+/* region adxl345bChangeMeasurementRange */
+void adxl345bChangeMeasurementRangeGetSendCommandFail_errorIfHardwarFails(void) {
+    i2cUnittestWriteCommand = i2cUnittestWriteCommandHardwareDefect;
+
+    adxl345bErrorCode_t errorCode = adxl345bChangeMeasurementRange(sensor, ADXL345B_2G_RANGE);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
+}
+
+void adxl345bChangeMeasurementRangeGetSendCommandFail_errorIfAckMissing(void) {
+    i2cUnittestWriteCommand = i2cUnittestWriteCommandAckMissing;
+
+    adxl345bErrorCode_t errorCode = adxl345bChangeMeasurementRange(sensor, ADXL345B_2G_RANGE);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
+}
+
+void adxl345bChangeMeasurementRangeGetReceiveDataFail_errorIfHardwarFails(void) {
+    i2cUnittestReadCommand = i2cUnittestReadCommandHardwareDefect;
+
+    adxl345bErrorCode_t errorCode = adxl345bChangeMeasurementRange(sensor, ADXL345B_2G_RANGE);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
+}
+
+void adxl345bChangeMeasurementRangeGetReceiveDataFail_errorIfAckMissing(void) {
+    i2cUnittestReadCommand = i2cUnittestReadCommandAckMissing;
+
+    adxl345bErrorCode_t errorCode = adxl345bChangeMeasurementRange(sensor, ADXL345B_2G_RANGE);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
+}
+
+void adxl345bChangeMeasurementRangeWrongRange(void) {
+    adxl345bErrorCode_t errorCode = adxl345bChangeMeasurementRange(sensor, 8);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_RANGE_ERROR, errorCode);
+}
+
+void adxl345bChangeMeasurementRangeChangeSuccessful(void) {
+    adxl345bErrorCode_t errorCode = adxl345bChangeMeasurementRange(sensor, ADXL345B_2G_RANGE);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_NO_ERROR, errorCode);
+}
+/* endregion adxl345bChangeMeasurementRange */
+
 /* region adxl345bGetSingleMeasurement */
 
 void adxl345bGetSingleMeasurementGetSendCommandFail_errorIfHardwareFails(void) {
-    uint8_t rawData[sizeOfSingleRawData];
+    adxl345bRawData_t rawData;
     i2cUnittestWriteCommand = i2cUnittestWriteCommandHardwareDefect;
 
-    adxl345bErrorCode_t errorCode = adxl345bGetSingleMeasurement(sensor, rawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
+    adxl345bErrorCode_t errorCode = adxl345bGetSingleMeasurement(sensor, &rawData);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
 }
 
 void adxl345bGetSingleMeasurementGetSendCommandFail_errorIfAckMissing(void) {
-    uint8_t rawData[sizeOfSingleRawData];
+    adxl345bRawData_t rawData;
     i2cUnittestWriteCommand = i2cUnittestWriteCommandAckMissing;
 
-    adxl345bErrorCode_t errorCode = adxl345bGetSingleMeasurement(sensor, rawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
+    adxl345bErrorCode_t errorCode = adxl345bGetSingleMeasurement(sensor, &rawData);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
 }
 
 void adxl345bGetSingleMeasurementGetReceiveDataFail_errorIfHardwareFails(void) {
-    uint8_t rawData[sizeOfSingleRawData];
+    adxl345bRawData_t rawData;
     i2cUnittestReadCommand = i2cUnittestReadCommandHardwareDefect;
 
-    adxl345bErrorCode_t errorCode = adxl345bGetSingleMeasurement(sensor, rawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
+    adxl345bErrorCode_t errorCode = adxl345bGetSingleMeasurement(sensor, &rawData);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
 }
 
 void adxl345bGetSingleMeasurementGetReceiveDataFail_errorIfAckMissing(void) {
-    uint8_t rawData[sizeOfSingleRawData];
+    adxl345bRawData_t rawData;
     i2cUnittestReadCommand = i2cUnittestReadCommandAckMissing;
 
-    adxl345bErrorCode_t errorCode = adxl345bGetSingleMeasurement(sensor, rawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
+    adxl345bErrorCode_t errorCode = adxl345bGetSingleMeasurement(sensor, &rawData);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
 }
 
 void adxl345bGetSingleMeasurementReadSuccessful(void) {
-    uint8_t rawData[sizeOfSingleRawData];
-    adxl345bErrorCode_t errorCode = adxl345bGetSingleMeasurement(sensor, rawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_NO_ERROR, errorCode);
+    adxl345bRawData_t rawData;
+    adxl345bErrorCode_t errorCode = adxl345bGetSingleMeasurement(sensor, &rawData);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_NO_ERROR, errorCode);
 }
 
 void adxl345bGetSingleMeasurementReadCorrectValue(void) {
-    uint8_t rawData[sizeOfSingleRawData];
-    memset(rawData, 0, sizeOfSingleRawData);
+    adxl345bRawData_t rawData;
+    uint8_t expectedRawData = byteZero;
 
-    adxl345bGetSingleMeasurement(sensor, rawData);
+    adxl345bGetSingleMeasurement(sensor, &rawData);
 
-    TEST_ASSERT_EACH_EQUAL_UINT8(byteZero, rawData, sizeOfSingleRawData);
+    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, rawData.data, sizeof(adxl345bRawData_t));
 }
 /* endregion adxl345bGetSingleMeasurement */
 
 /* region adxl345bGetMultipleMeasurements */
 
 void adxl345bGetMultipleMeasurementsGetSendCommandFail_errorIfHardwareFails(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
+    adxl345bRawData_t samples[numberOfSamples];
 
     i2cUnittestWriteCommand = i2cUnittestWriteCommandHardwareDefect;
 
     adxl345bErrorCode_t errorCode =
-        adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
+        adxl345bGetMultipleMeasurements(sensor, samples, numberOfSamples);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
 }
 
 void adxl345bGetMultipleMeasurementsGetSendCommandFail_errorIfAckMissing(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
+    adxl345bRawData_t samples[numberOfSamples];
     i2cUnittestWriteCommand = i2cUnittestWriteCommandAckMissing;
 
     adxl345bErrorCode_t errorCode =
-        adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
+        adxl345bGetMultipleMeasurements(sensor, samples, numberOfSamples);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
 }
 
 void adxl345bGetMultipleMeasurementsGetReceiveDataFail_errorIfHardwareFails(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
+    adxl345bRawData_t samples[numberOfSamples];
     i2cUnittestReadCommand = i2cUnittestReadCommandHardwareDefect;
 
     adxl345bErrorCode_t errorCode =
-        adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
+        adxl345bGetMultipleMeasurements(sensor, samples, numberOfSamples);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
 }
 
 void adxl345bGetMultipleMeasurementsGetReceiveDataFail_errorIfAckMissing(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
+    adxl345bRawData_t samples[numberOfSamples];
     i2cUnittestReadCommand = i2cUnittestReadCommandAckMissing;
 
     adxl345bErrorCode_t errorCode =
-        adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
+        adxl345bGetMultipleMeasurements(sensor, samples, numberOfSamples);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
 }
 
 void adxl345bGetMultipleMeasurementsReadSuccessful(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
+    adxl345bRawData_t samples[numberOfSamples];
 
     adxl345bErrorCode_t errorCode =
-        adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_NO_ERROR, errorCode);
+        adxl345bGetMultipleMeasurements(sensor, samples, numberOfSamples);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_NO_ERROR, errorCode);
 }
-
-void adxl345bGetMultipleMeasurementsCheckOverwritingDataInStreamMode(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
-
-    adxl345bErrorCode_t errorCode =
-        adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData);
-    if (errorCode != ADXL345B_NO_ERROR) {
-        TEST_FAIL_MESSAGE("If this ever occurs and no other test fails, please write test for it.");
-    }
-
-    // check if some data is 0
-    uint8_t counter = 0;
-    for (int i = 0; i < (sizeOfRequestedRawData); i += sizeOfSingleRawData) {
-        if (samples[i] == 0) {
-            counter++;
-
-        } else {
-            printf("%d should be 10011111 but is: %b \n", i, samples[i]);
-            counter = 0;
-        }
-    }
-    TEST_ASSERT_EQUAL(0, counter);
-}
-
-void adxl345bGetMultipleMeasurementsCheckOverwritingDataInFifoMode(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
-
-    /* change ReadCommands to generate expected raw data received from I2C*/
-    i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInFifoMode;
-
-    adxl345bErrorCode_t errorCode =
-        adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData);
-    if (errorCode != ADXL345B_NO_ERROR) {
-        TEST_FAIL_MESSAGE("If this ever occurs and no other test fails, please write test for it.");
-    }
-
-    // check if some data is 0
-    uint8_t counter = 0;
-    for (int i = 0; i < (sizeOfRequestedRawData); i += sizeOfSingleRawData) {
-        if (samples[i] == 0) {
-            counter++;
-
-        } else {
-            printf("%d should be 10011111 but is: %b \n", i, samples[i]);
-            counter = 0;
-        }
-    }
-    TEST_ASSERT_EQUAL(0, counter);
-}
-
-void adxl345bGetMultipleMeasurementsCheckOverwritingDataInTriggerMode(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
-
-    /* change ReadCommands to generate expected raw data received from I2C*/
-    i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInTriggerMode;
-
-    adxl345bErrorCode_t errorCode =
-        adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData);
-    if (errorCode != ADXL345B_NO_ERROR) {
-        TEST_FAIL_MESSAGE("If this ever occurs and no other test fails, please write test for it.");
-    }
-
-    // check if some data is 0
-    uint8_t counter = 0;
-    for (int i = 0; i < (sizeOfRequestedRawData); i += sizeOfSingleRawData) {
-        if (samples[i] == 0) {
-            counter++;
-        } else {
-            printf("%d should be 10011111 but is: %b \n", i, samples[i]);
-            counter = 0;
-        }
-    }
-    TEST_ASSERT_EQUAL(0, counter);
-}
-
 /* region GetMultipleMeasurementsReadCorrectValues */
-void adxl345bGetMultipleMeasurementsReadCorrectValuesInBypassModeWithCorrectSizedArray(void) {
+void adxl345bGetMultipleMeasurementsReadCorrectValuesInBypassMode(void) {
     /*generate Array for Data*/
-    uint8_t samples[sizeOfSingleRawData];
-    memset(samples, 0, sizeOfSingleRawData);
+    adxl345bRawData_t samples[numberOfSamples];
 
     uint8_t expectedRawData = byteZero;
 
-    adxl345bGetMultipleMeasurements(sensor, samples, sizeOfSingleRawData);
+    adxl345bGetMultipleMeasurements(sensor, samples, numberOfSamples);
 
-    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfSingleRawData);
+    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, numberOfSamples);
 }
 
-void adxl345bGetMultipleMeasurementsReadCorrectValuesInBypassModeWithWrongSizedArray(void) {
+void adxl345bGetMultipleMeasurementsReadCorrectValuesInStreamMode(void) {
     /*generate Array for Data*/
-    uint8_t samples[sizeOfSingleRawData];
-    uint8_t wrongSize = 1;
-    memset(samples, 0, sizeOfSingleRawData + wrongSize);
-
-    uint8_t expectedRawData = byteZero;
-
-    adxl345bGetMultipleMeasurements(sensor, samples, sizeOfSingleRawData + wrongSize);
-
-    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfSingleRawData);
-    TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfSingleRawData], wrongSize);
-}
-
-void adxl345bGetMultipleMeasurementsReadCorrectValuesInStreamModeWithCorrectSizedArray(void) {
-    /*generate Array for Data*/
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
+    adxl345bRawData_t samples[numberOfSamples];
 
     /* change ReadCommands to generate expected raw data received from I2C*/
     i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInStreamMode;
     uint8_t expectedRawData = byteOne;
 
-    adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData);
+    adxl345bGetMultipleMeasurements(sensor, samples, numberOfSamples);
 
-    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
+    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, numberOfSamples);
 }
 
-void adxl345bGetMultipleMeasurementsReadCorrectValuesInStreamModeWithWrongSizedArray(void) {
+void adxl345bGetMultipleMeasurementsReadCorrectValuesInFiFoMode(void) {
     /*generate Array for Data*/
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t wrongSize = 5;
-    uint8_t samples[sizeOfRequestedRawData + wrongSize];
-    memset(samples, 0, sizeOfRequestedRawData + wrongSize);
-
-    /* change ReadCommands to generate expected raw data received from I2C*/
-    i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInStreamMode;
-    uint8_t expectedRawData = byteOne;
-
-    adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData + wrongSize);
-
-    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
-    TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfRequestedRawData], wrongSize);
-}
-
-void adxl345bGetMultipleMeasurementsReadCorrectValuesInFiFoModeWithCorrectSizedArray(void) {
-    /*generate Array for Data*/
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
+    adxl345bRawData_t samples[numberOfSamples];
 
     /* change ReadCommands to generate expected raw data received from I2C*/
     i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInFifoMode;
-    uint8_t expectedRawData = byteTwo;
+    uint8_t expectedRawData = byteZero;
 
-    adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData);
+    adxl345bGetMultipleMeasurements(sensor, samples, numberOfSamples);
 
-    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
+    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, numberOfSamples);
 }
 
-void adxl345bGetMultipleMeasurementsReadCorrectValuesInFiFoModeWithWrongSizedArray(void) {
+void adxl345bGetMultipleMeasurementsReadCorrectValuesInTriggerMode(void) {
     /*generate Array for Data*/
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t wrongSize = 1;
-    uint8_t samples[sizeOfRequestedRawData + wrongSize];
-    memset(samples, 0, sizeOfRequestedRawData + wrongSize);
-
-    /* change ReadCommands to generate expected raw data received from I2C*/
-    i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInFifoMode;
-    uint8_t expectedRawData = byteTwo;
-
-    adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData + wrongSize);
-
-    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
-    TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfRequestedRawData], wrongSize);
-}
-
-void adxl345bGetMultipleMeasurementsReadCorrectValuesInTriggerModeWithCorrectSizedArray(void) {
-    /*generate Array for Data*/
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
+    adxl345bRawData_t samples[numberOfSamples];
 
     /* change ReadCommands to generate expected raw data received from I2C*/
     i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInTriggerMode;
-    uint8_t expectedRawData = byteThree;
+    uint8_t expectedRawData = byteZero;
 
-    adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData);
+    adxl345bGetMultipleMeasurements(sensor, samples, numberOfSamples);
 
-    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
+    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, numberOfSamples);
 }
 
-void adxl345bGetMultipleMeasurementsReadCorrectValuesInTriggerModeWithWrongSizedArray(void) {
-    /*generate Array for Data*/
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t wrongSize = 3;
-    uint8_t samples[sizeOfRequestedRawData + wrongSize];
-    memset(samples, 0, sizeOfRequestedRawData + wrongSize);
-
-    /* change ReadCommands to generate expected raw data received from I2C*/
-    i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInTriggerMode;
-    uint8_t expectedRawData = byteThree;
-
-    adxl345bGetMultipleMeasurements(sensor, samples, sizeOfRequestedRawData + wrongSize);
-
-    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
-    TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfRequestedRawData], wrongSize);
-}
 /* endregion GetMultipleMeasurementsReadCorrectValues */
 /* endregion adxl345bGetMultipleMeasurements */
 
-/* region adxl345bGetMeasurementsForNMilliseconds */
+/* region adxl345bGetMeasurementsForNMicroseconds */
 
-void adxl345bGetMeasurementsForNMillisecondsGetSendCommandFail_errorIfHardwareFails(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
+void adxl345bGetMeasurementsForNMicrosecondsGetSendCommandFail_errorIfHardwareFails(void) {
+    adxl345bRawData_t samples[numberOfSamples];
 
     i2cUnittestWriteCommand = i2cUnittestWriteCommandHardwareDefect;
+    adxl345bErrorCode_t errorCode =
+        adxl345bGetMeasurementsForNMicroseconds(sensor, microseconds, samples, numberOfSamples);
 
-    adxl345bErrorCode_t errorCode = adxl345bGetMeasurementsForNMilliseconds(
-        sensor, samples, milliseconds, &sizeOfRequestedRawData);
-
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
 }
 
-void adxl345bGetMeasurementsForNMillisecondsGetSendCommandFail_errorIfAckMissing(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
+void adxl345bGetMeasurementsForNMicrosecondsGetSendCommandFail_errorIfAckMissing(void) {
+    adxl345bRawData_t samples[numberOfSamples];
 
     i2cUnittestWriteCommand = i2cUnittestWriteCommandAckMissing;
 
-    adxl345bErrorCode_t errorCode = adxl345bGetMeasurementsForNMilliseconds(
-        sensor, samples, milliseconds, &sizeOfRequestedRawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
+    adxl345bErrorCode_t errorCode =
+        adxl345bGetMeasurementsForNMicroseconds(sensor, microseconds, samples, numberOfSamples);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_SEND_COMMAND_ERROR, errorCode);
 }
 
-void adxl345bGetMeasurementsForNMillisecondsGetReceiveDataFail_errorIfHardwareFails(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
+void adxl345bGetMeasurementsForNMicrosecondsGetReceiveDataFail_errorIfHardwareFails(void) {
+    adxl345bRawData_t samples[numberOfSamples];
 
     i2cUnittestReadCommand = i2cUnittestReadCommandHardwareDefect;
 
-    adxl345bErrorCode_t errorCode = adxl345bGetMeasurementsForNMilliseconds(
-        sensor, samples, milliseconds, &sizeOfRequestedRawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
+    adxl345bErrorCode_t errorCode =
+        adxl345bGetMeasurementsForNMicroseconds(sensor, microseconds, samples, numberOfSamples);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
 }
 
-void adxl345bGetMeasurementsForNMillisecondsGetReceiveDataFail_errorIfAckMissing(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
+void adxl345bGetMeasurementsForNMicrosecondsGetReceiveDataFail_errorIfAckMissing(void) {
+    adxl345bRawData_t samples[numberOfSamples];
 
     i2cUnittestReadCommand = i2cUnittestReadCommandAckMissing;
 
-    adxl345bErrorCode_t errorCode = adxl345bGetMeasurementsForNMilliseconds(
-        sensor, samples, milliseconds, &sizeOfRequestedRawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
+    adxl345bErrorCode_t errorCode =
+        adxl345bGetMeasurementsForNMicroseconds(sensor, microseconds, samples, numberOfSamples);
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_RECEIVE_DATA_ERROR, errorCode);
 }
 
-void adxl345bGetMeasurementsForNMillisecondsReadSuccessfulInBypassMode(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
-    milliseconds = 2;
+void adxl345bGetMeasurementsForNMicrosecondsReadSuccessfulInBypassMode(void) {
+    adxl345bRawData_t samples[numberOfSamples];
 
-    adxl345bErrorCode_t errorCode = adxl345bGetMeasurementsForNMilliseconds(
-        sensor, samples, milliseconds, &sizeOfRequestedRawData);
+    microseconds = 2;
 
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_NO_ERROR, errorCode);
+    adxl345bErrorCode_t errorCode =
+        adxl345bGetMeasurementsForNMicroseconds(sensor, microseconds, samples, numberOfSamples);
+    /* we expect a parameter error, because we use DUMMY-TIME-FACADE-LIB */
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_PARM_ERROR, errorCode);
 }
 
-void adxl345bGetMeasurementsForNMillisecondsReadSuccessfulInStreamMode(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
-    milliseconds = 30;
+void adxl345bGetMeasurementsForNMicrosecondsReadSuccessfulInStreamMode(void) {
+    microseconds = 30;
+    adxl345bRawData_t samples[numberOfSamples];
+
     i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInStreamMode;
 
-    adxl345bErrorCode_t errorCode = adxl345bGetMeasurementsForNMilliseconds(
-        sensor, samples, milliseconds, &sizeOfRequestedRawData);
+    adxl345bErrorCode_t errorCode =
+        adxl345bGetMeasurementsForNMicroseconds(sensor, microseconds, samples, numberOfSamples);
 
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_NO_ERROR, errorCode);
+    /* we expect a parameter error, because we use DUMMY-TIME-FACADE-LIB */
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_PARM_ERROR, errorCode);
 }
 
-void adxl345bGetMeasurementsForNMillisecondsReadSuccessfulInFifoMode(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    // ensure all Data is 0
-    for (int i = 0; i < sizeOfRequestedRawData; i++) {
-        samples[i] = 0;
-    }
-    milliseconds = 40;
+void adxl345bGetMeasurementsForNMicrosecondsReadSuccessfulInFifoMode(void) {
+    adxl345bRawData_t samples[numberOfSamples];
+    microseconds = 40;
 
     i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInFifoMode;
 
-    adxl345bErrorCode_t errorCode = adxl345bGetMeasurementsForNMilliseconds(
-        sensor, samples, milliseconds, &sizeOfRequestedRawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_NO_ERROR, errorCode);
+    adxl345bErrorCode_t errorCode =
+        adxl345bGetMeasurementsForNMicroseconds(sensor, microseconds, samples, numberOfSamples);
+    /* we expect a parameter error, because we use DUMMY-TIME-FACADE-LIB */
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_PARM_ERROR, errorCode);
 }
 
-void adxl345bGetMeasurementsForNMillisecondsReadSuccessfulInTriggerMode(void) {
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
-    milliseconds = 50;
+void adxl345bGetMeasurementsForNMicrosecondsReadSuccessfulInTriggerMode(void) {
+    adxl345bRawData_t samples[numberOfSamples];
+
+    microseconds = 50;
     i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInTriggerMode;
 
-    adxl345bErrorCode_t errorCode = adxl345bGetMeasurementsForNMilliseconds(
-        sensor, samples, milliseconds, &sizeOfRequestedRawData);
-    TEST_ASSERT_EQUAL_UINT8(ADXL345B_NO_ERROR, errorCode);
+    adxl345bErrorCode_t errorCode =
+        adxl345bGetMeasurementsForNMicroseconds(sensor, microseconds, samples, numberOfSamples);
+    /* we expect a parameter error, because we use DUMMY-TIME-FACADE-LIB */
+    TEST_ASSERT_EQUAL_HEX8(ADXL345B_PARM_ERROR, errorCode);
 }
 
-/* region GetMeasurementsForNMillisecondsReadCorrectValues */
-void adxl345bGetMeasurementsForNMillisecondsReadCorrectValuesInStreamModeWithCorrectSizedArray(
-    void) {
-    milliseconds = 60;
+/* region GetMeasurementsForNmicrosecondsReadCorrectValues */
+void adxl345bGetMeasurementsForNMicrosecondsReadCorrectValuesInStreamMode(void) {
+    microseconds = 60;
 
     /*generate Array for Data*/
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
+    adxl345bRawData_t samples[numberOfSamples];
 
     /* change ReadCommands to generate expected raw data received from I2C*/
     i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInStreamMode;
     uint8_t expectedRawData = byteOne;
 
-    adxl345bGetMeasurementsForNMilliseconds(sensor, samples, milliseconds, &sizeOfRequestedRawData);
-
-    if (sizeOfRequestedRawData < (numberOfSamples * sizeOfRequestedRawData)) {
-        TEST_MESSAGE("case: (given milliseconds) < (reading-time until buffer is completely full)");
-        TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
-        if (sizeOfRequestedRawData % 6 != 0) {
-            TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfRequestedRawData],
-                                         (numberOfSamples * sizeOfSingleRawData) -
-                                             sizeOfRequestedRawData);
-            TEST_FAIL_MESSAGE("adxl345bGetMeasurementsForNMilliseconds probably has a problem with "
-                              "handling the size of rawdata");
-        }
-    } else if (sizeOfRequestedRawData == (numberOfSamples * sizeOfRequestedRawData)) {
-        TEST_MESSAGE("case: given buffer was too small for given milliseconds");
-        TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
-    } else {
-        TEST_FAIL_MESSAGE("adxl345bGetMeasurementsForNMilliseconds probably returns wrong "
-                          "sizeOfRequestedRawData (or else)");
+    adxl345bErrorCode_t errorCode =
+        adxl345bGetMeasurementsForNMicroseconds(sensor, microseconds, samples, numberOfSamples);
+    /* we expect a parameter error, because we use DUMMY-TIME-FACADE-LIB */
+    if (errorCode != ADXL345B_PARM_ERROR) {
+        TEST_FAIL();
     }
+    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples,
+                                 numberOfSamples * sizeof(adxl345bRawData_t));
 }
 
-void adxl345bGetMeasurementsForNMillisecondsReadCorrectValuesInStreamModeWithWrongSizedArray(void) {
-    milliseconds = 70;
+void adxl345bGetMeasurementsForNMicrosecondsReadCorrectValuesInFifoMode(void) {
+    microseconds = 800;
 
     /*generate Array for Data*/
 
-    uint8_t wrongSize = 5;
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData + wrongSize;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
+    adxl345bRawData_t samples[numberOfSamples];
 
-    /* change ReadCommands to generate expected raw data received from I2C*/
-    i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInStreamMode;
-    uint8_t expectedRawData = byteOne;
-
-    adxl345bGetMeasurementsForNMilliseconds(sensor, samples, milliseconds, &sizeOfRequestedRawData);
-
-    if (sizeOfRequestedRawData < (numberOfSamples * sizeOfRequestedRawData + wrongSize)) {
-        TEST_MESSAGE("case: (given milliseconds) < (reading-time until buffer is completely full)");
-        TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
-        TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfRequestedRawData],
-                                     (numberOfSamples * sizeOfSingleRawData + wrongSize) -
-                                         sizeOfRequestedRawData);
-    } else {
-        TEST_MESSAGE("case: given buffer was too small for given milliseconds");
-        TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData - wrongSize);
-        TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfRequestedRawData - wrongSize], wrongSize);
-    }
-}
-
-void adxl345bGetMeasurementsForNMillisecondsReadCorrectValuesInFifoModeWithCorrectSizedArray(void) {
-    milliseconds = 800;
-
-    /*generate Array for Data*/
-
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
     /* change ReadCommands to generate expected raw data received from I2C*/
     i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInFifoMode;
-    uint8_t expectedRawData = byteTwo;
+    uint8_t expectedRawData = byteZero;
 
-    adxl345bGetMeasurementsForNMilliseconds(sensor, samples, milliseconds, &sizeOfRequestedRawData);
-
-    if (sizeOfRequestedRawData < (numberOfSamples * sizeOfRequestedRawData)) {
-        TEST_MESSAGE("case: (given milliseconds) < (reading-time until buffer is completely full)");
-        TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
-        if (sizeOfRequestedRawData % 6 != 0) {
-            TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfRequestedRawData],
-                                         (numberOfSamples * sizeOfSingleRawData) -
-                                             sizeOfRequestedRawData);
-            TEST_FAIL_MESSAGE("adxl345bGetMeasurementsForNMilliseconds probably has a problem with "
-                              "handling the size of rawdata");
-        }
-    } else if (sizeOfRequestedRawData == (numberOfSamples * sizeOfRequestedRawData)) {
-        TEST_MESSAGE("case: given buffer was too small for given milliseconds");
-        TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
-    } else {
-        TEST_FAIL_MESSAGE("adxl345bGetMeasurementsForNMilliseconds probably returns wrong "
-                          "sizeOfRequestedRawData (or else)");
+    adxl345bErrorCode_t errorCode =
+        adxl345bGetMeasurementsForNMicroseconds(sensor, microseconds, samples, numberOfSamples);
+    /* we expect a parameter error, because we use DUMMY-TIME-FACADE-LIB */
+    if (errorCode != ADXL345B_PARM_ERROR) {
+        TEST_FAIL();
     }
+    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples,
+                                 numberOfSamples * sizeof(adxl345bRawData_t));
 }
 
-void adxl345bGetMeasurementsForNMillisecondsReadCorrectValuesInFifoModeWithWrongSizedArray(void) {
-    milliseconds = 900;
+void adxl345bGetMeasurementsForNMicrosecondsReadCorrectValuesInTriggerMode(void) {
+    microseconds = 1000;
 
     /*generate Array for Data*/
-
-    uint8_t wrongSize = 1;
-    uint32_t sizeOfRequestedRawData = (numberOfSamples * sizeOfSingleRawData) + wrongSize;
-
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
-    /* change ReadCommands to generate expected raw data received from I2C*/
-    i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInFifoMode;
-    uint8_t expectedRawData = byteTwo;
-
-    adxl345bGetMeasurementsForNMilliseconds(sensor, samples, milliseconds, &sizeOfRequestedRawData);
-
-    if (sizeOfRequestedRawData < (numberOfSamples * sizeOfRequestedRawData + wrongSize)) {
-        TEST_MESSAGE("case: (given milliseconds) < (reading-time until buffer is completely full)");
-        TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
-        TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfRequestedRawData],
-                                     (numberOfSamples * sizeOfSingleRawData + wrongSize) -
-                                         sizeOfRequestedRawData);
-    } else {
-        TEST_MESSAGE("case: given buffer was too small for given milliseconds");
-        TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData - wrongSize);
-        TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfRequestedRawData - wrongSize], wrongSize);
-    }
-}
-
-void adxl345bGetMeasurementsForNMillisecondsReadCorrectValuesInTriggerModeWithCorrectSizedArray(
-    void) {
-    milliseconds = 1000;
-
-    /*generate Array for Data*/
-
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
+    adxl345bRawData_t samples[numberOfSamples];
 
     /* change ReadCommands to generate expected raw data received from I2C*/
     i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInTriggerMode;
-    uint8_t expectedRawData = byteThree;
+    uint8_t expectedRawData = byteZero;
 
-    adxl345bGetMeasurementsForNMilliseconds(sensor, samples, milliseconds, &sizeOfRequestedRawData);
-
-    if (sizeOfRequestedRawData < (numberOfSamples * sizeOfRequestedRawData)) {
-        TEST_MESSAGE("case: (given milliseconds) < (reading-time until buffer is completely full)");
-        TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
-        if (sizeOfRequestedRawData % 6 != 0) {
-            TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfRequestedRawData],
-                                         (numberOfSamples * sizeOfSingleRawData) -
-                                             sizeOfRequestedRawData);
-            TEST_FAIL_MESSAGE("adxl345bGetMeasurementsForNMilliseconds probably has a problem with "
-                              "handling the size of rawdata");
-        }
-    } else if (sizeOfRequestedRawData == (numberOfSamples * sizeOfRequestedRawData)) {
-        TEST_MESSAGE("case: given buffer was too small for given milliseconds");
-        TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
-    } else {
-        TEST_FAIL_MESSAGE("adxl345bGetMeasurementsForNMilliseconds probably returns wrong "
-                          "sizeOfRequestedRawData (or else)");
+    adxl345bErrorCode_t errorCode =
+        adxl345bGetMeasurementsForNMicroseconds(sensor, microseconds, samples, numberOfSamples);
+    /* we expect a parameter error, because we use DUMMY-TIME-FACADE-LIB */
+    if (errorCode != ADXL345B_PARM_ERROR) {
+        TEST_FAIL();
     }
+    TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples,
+                                 numberOfSamples * sizeof(adxl345bRawData_t));
 }
 
-void adxl345bGetMeasurementsForNMillisecondsReadCorrectValuesInTriggerModeWithWrongSizedArray(
-    void) {
-    milliseconds = 11000;
+/* endregion GetMeasurementsForNmicrosecondsReadCorrectValues */
+/* endregion adxl345bGetMeasurementsForNMicroseconds */
 
-    /*generate Array for Data*/
-    uint8_t wrongSize = 2;
-    uint32_t sizeOfRequestedRawData = numberOfSamples * sizeOfSingleRawData + wrongSize;
-    uint8_t samples[sizeOfRequestedRawData];
-    memset(samples, 0, sizeOfRequestedRawData);
-
-    /* change ReadCommands to generate expected raw data received from I2C*/
-    i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bInTriggerMode;
-    uint8_t expectedRawData = byteThree;
-
-    adxl345bGetMeasurementsForNMilliseconds(sensor, samples, milliseconds, &sizeOfRequestedRawData);
-
-    if (sizeOfRequestedRawData < (numberOfSamples * sizeOfRequestedRawData + wrongSize)) {
-        TEST_MESSAGE("case: (given milliseconds) < (reading-time until buffer is completely full)");
-        TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData);
-        TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfRequestedRawData],
-                                     (numberOfSamples * sizeOfSingleRawData + wrongSize) -
-                                         sizeOfRequestedRawData);
-    } else {
-        TEST_MESSAGE("case: given buffer was too small for given milliseconds");
-        TEST_ASSERT_EACH_EQUAL_UINT8(expectedRawData, samples, sizeOfRequestedRawData - wrongSize);
-        TEST_ASSERT_EACH_EQUAL_UINT8(0, &samples[sizeOfRequestedRawData - wrongSize], wrongSize);
-    }
-}
-/* endregion GetMeasurementsForNMillisecondsReadCorrectValues */
-/* endregion adxl345bGetMeasurementsForNMilliseconds */
-
-void adxl345bConvertDataXYZCorrectValue(void) {
-    /* test assumes that 2G Full Range is the used Range */
-
-    float expected_xAxis = 0, expected_yAxis = 0, expected_zAxis = 0;
+void adxl345bConvertDataXYZCorrectValueWithFullResON(void) {
+    float expected_xAxis = -1.213940f, expected_yAxis = -1.213940f, expected_zAxis = -1.213940f;
     float actual_xAxis = 0, actual_yAxis = 0, actual_zAxis = 0;
-    const uint8_t MSB_MASK = 0b00000011;
-    const float SCALE_FACTOR_FOR_RANGE = 0.00377f;
-    /* only used lower 2 bits -> 2G Range consists of 10 Bit*/
-    uint8_t topByte = byteZero & MSB_MASK;
-
     /* set rawData */
-    uint8_t rawData[sizeOfSingleRawData];
-    memset(rawData, 0, sizeOfSingleRawData);
+    adxl345bRawData_t rawData;
+    memset(&rawData, byteZero, sizeof(rawData));
 
-    /* fill expected with random generated */
-    if (topByte <= (MSB_MASK >> 1)) {
-        /* CASE: positive value */
-        int rawValue = (int)(((uint16_t)(topByte & MSB_MASK) << 8) | (uint16_t)byteZero);
-        float realValue = (float)rawValue * SCALE_FACTOR_FOR_RANGE;
-        expected_xAxis = expected_yAxis = expected_zAxis = realValue;
-    } else {
-        /* CASE: negative value
-         *
-         * 1. revert 10 bit two complement
-         * -> number-1 and Flip least 9 bits
-         * 2. convert to float value
-         * 3. multiply with (-1)
-         * 4. multiply with scale factor
-         */
-        uint16_t rawValue = ((uint16_t)(topByte & (MSB_MASK >> 1)) << 8) | (uint16_t)byteZero;
-        rawValue = (rawValue - 0x0001) ^ (((MSB_MASK >> 1) << 8) | 0x00FF);
-        float realValue = (-1) * (float)rawValue * SCALE_FACTOR_FOR_RANGE;
-        expected_xAxis = expected_yAxis = expected_zAxis = realValue;
+    i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bWithFullResON;
+    adxl345bErrorCode_t errorCode =
+        adxl345bConvertDataXYZ(sensor, &actual_xAxis, &actual_yAxis, &actual_zAxis, rawData);
+    if (errorCode != ADXL345B_NO_ERROR) {
+        printf("adxl345bConvertDataXYZ failed; adxl345b_ERROR: %02X", errorCode);
+        TEST_FAIL();
     }
-    adxl345bGetSingleMeasurement(sensor, rawData);
-    adxl345bConvertDataXYZ(sensor, &actual_xAxis, &actual_yAxis, &actual_zAxis, rawData);
+
+    TEST_ASSERT_EQUAL_FLOAT(expected_xAxis, actual_xAxis);
+    TEST_ASSERT_EQUAL_FLOAT(expected_yAxis, actual_yAxis);
+    TEST_ASSERT_EQUAL_FLOAT(expected_zAxis, actual_zAxis);
+}
+
+void adxl345bConvertDataXYZCorrectValueWithFullResOFF(void) {
+    /* test assumes 10bit-2G Range*/
+    float expected_xAxis = -1.213940f, expected_yAxis = -1.213940f, expected_zAxis = -1.213940f;
+    float actual_xAxis = 0, actual_yAxis = 0, actual_zAxis = 0;
+    /* set rawData */
+    adxl345bRawData_t rawData;
+    memset(&rawData, byteZero, sizeof(rawData));
+
+    i2cUnittestReadCommand = i2cUnittestReadCommandPassForAdxl345bWithFullResOFF;
+    adxl345bErrorCode_t errorCode =
+            adxl345bConvertDataXYZ(sensor, &actual_xAxis, &actual_yAxis, &actual_zAxis, rawData);
+    if (errorCode != ADXL345B_NO_ERROR) {
+        printf("adxl345bConvertDataXYZ failed; adxl345b_ERROR: %02X", errorCode);
+        TEST_FAIL();
+    }
 
     TEST_ASSERT_EQUAL_FLOAT(expected_xAxis, actual_xAxis);
     TEST_ASSERT_EQUAL_FLOAT(expected_yAxis, actual_yAxis);
@@ -723,7 +464,6 @@ void adxl345bConvertDataXYZCorrectValue(void) {
 int main(void) {
     UNITY_BEGIN();
 
-    // ReadSerialNumber
     RUN_TEST(adxl345bReadSerialNumberGetSendCommandFail_errorIfHardwarFails);
     RUN_TEST(adxl345bReadSerialNumberGetSendCommandFail_errorIfAckMissing);
     RUN_TEST(adxl345bReadSerialNumberGetReceiveDataFail_errorIfHardwarFails);
@@ -731,7 +471,13 @@ int main(void) {
     RUN_TEST(adxl345bReadSerialNumberReadSuccessful);
     RUN_TEST(adxl345bReadSerialNumberReadCorrectValue);
 
-    // GetSingleMeasurement
+    RUN_TEST(adxl345bChangeMeasurementRangeGetSendCommandFail_errorIfHardwarFails);
+    RUN_TEST(adxl345bChangeMeasurementRangeGetSendCommandFail_errorIfAckMissing);
+    RUN_TEST(adxl345bChangeMeasurementRangeGetReceiveDataFail_errorIfHardwarFails);
+    RUN_TEST(adxl345bChangeMeasurementRangeGetReceiveDataFail_errorIfAckMissing);
+    RUN_TEST(adxl345bChangeMeasurementRangeWrongRange);
+    RUN_TEST(adxl345bChangeMeasurementRangeChangeSuccessful);
+
     RUN_TEST(adxl345bGetSingleMeasurementGetSendCommandFail_errorIfHardwareFails);
     RUN_TEST(adxl345bGetSingleMeasurementGetSendCommandFail_errorIfAckMissing);
     RUN_TEST(adxl345bGetSingleMeasurementGetReceiveDataFail_errorIfHardwareFails);
@@ -739,48 +485,33 @@ int main(void) {
     RUN_TEST(adxl345bGetSingleMeasurementReadSuccessful);
     RUN_TEST(adxl345bGetSingleMeasurementReadCorrectValue);
 
-    // GetMultipleMeasurements
     RUN_TEST(adxl345bGetMultipleMeasurementsGetSendCommandFail_errorIfHardwareFails);
     RUN_TEST(adxl345bGetMultipleMeasurementsGetSendCommandFail_errorIfAckMissing);
     RUN_TEST(adxl345bGetMultipleMeasurementsGetReceiveDataFail_errorIfHardwareFails);
     RUN_TEST(adxl345bGetMultipleMeasurementsGetReceiveDataFail_errorIfAckMissing);
     RUN_TEST(adxl345bGetMultipleMeasurementsReadSuccessful);
 
-    RUN_TEST(adxl345bGetMultipleMeasurementsReadCorrectValuesInFiFoModeWithCorrectSizedArray);
-    RUN_TEST(adxl345bGetMultipleMeasurementsReadCorrectValuesInStreamModeWithCorrectSizedArray);
-    RUN_TEST(adxl345bGetMultipleMeasurementsReadCorrectValuesInTriggerModeWithCorrectSizedArray);
-    RUN_TEST(adxl345bGetMultipleMeasurementsReadCorrectValuesInFiFoModeWithWrongSizedArray);
-    RUN_TEST(adxl345bGetMultipleMeasurementsReadCorrectValuesInStreamModeWithWrongSizedArray);
-    RUN_TEST(adxl345bGetMultipleMeasurementsReadCorrectValuesInTriggerModeWithWrongSizedArray);
+    RUN_TEST(adxl345bGetMultipleMeasurementsReadCorrectValuesInBypassMode);
+    RUN_TEST(adxl345bGetMultipleMeasurementsReadCorrectValuesInFiFoMode);
+    RUN_TEST(adxl345bGetMultipleMeasurementsReadCorrectValuesInStreamMode);
+    RUN_TEST(adxl345bGetMultipleMeasurementsReadCorrectValuesInTriggerMode);
 
-    RUN_TEST(adxl345bGetMultipleMeasurementsCheckOverwritingDataInStreamMode);
-    RUN_TEST(adxl345bGetMultipleMeasurementsCheckOverwritingDataInFifoMode);
-    RUN_TEST(adxl345bGetMultipleMeasurementsCheckOverwritingDataInTriggerMode);
+    RUN_TEST(adxl345bGetMeasurementsForNMicrosecondsGetSendCommandFail_errorIfHardwareFails);
+    RUN_TEST(adxl345bGetMeasurementsForNMicrosecondsGetSendCommandFail_errorIfAckMissing);
+    RUN_TEST(adxl345bGetMeasurementsForNMicrosecondsGetReceiveDataFail_errorIfHardwareFails);
+    RUN_TEST(adxl345bGetMeasurementsForNMicrosecondsGetReceiveDataFail_errorIfAckMissing);
 
-    // GetMeasurementsForNMilliseconds
-    RUN_TEST(adxl345bGetMeasurementsForNMillisecondsGetSendCommandFail_errorIfHardwareFails);
-    RUN_TEST(adxl345bGetMeasurementsForNMillisecondsGetSendCommandFail_errorIfAckMissing);
-    RUN_TEST(adxl345bGetMeasurementsForNMillisecondsGetReceiveDataFail_errorIfHardwareFails);
-    RUN_TEST(adxl345bGetMeasurementsForNMillisecondsGetReceiveDataFail_errorIfAckMissing);
+    RUN_TEST(adxl345bGetMeasurementsForNMicrosecondsReadSuccessfulInBypassMode);
+    RUN_TEST(adxl345bGetMeasurementsForNMicrosecondsReadSuccessfulInStreamMode);
+    RUN_TEST(adxl345bGetMeasurementsForNMicrosecondsReadSuccessfulInFifoMode);
+    RUN_TEST(adxl345bGetMeasurementsForNMicrosecondsReadSuccessfulInTriggerMode);
 
-    RUN_TEST(adxl345bGetMeasurementsForNMillisecondsReadSuccessfulInBypassMode);
-    RUN_TEST(adxl345bGetMeasurementsForNMillisecondsReadSuccessfulInStreamMode);
-    RUN_TEST(adxl345bGetMeasurementsForNMillisecondsReadSuccessfulInFifoMode);
-    RUN_TEST(adxl345bGetMeasurementsForNMillisecondsReadSuccessfulInTriggerMode);
+    RUN_TEST(adxl345bGetMultipleMeasurementsReadCorrectValuesInBypassMode);
+    RUN_TEST(adxl345bGetMeasurementsForNMicrosecondsReadCorrectValuesInStreamMode);
+    RUN_TEST(adxl345bGetMeasurementsForNMicrosecondsReadCorrectValuesInFifoMode);
+    RUN_TEST(adxl345bGetMeasurementsForNMicrosecondsReadCorrectValuesInTriggerMode);
 
-    RUN_TEST(
-        adxl345bGetMeasurementsForNMillisecondsReadCorrectValuesInStreamModeWithCorrectSizedArray);
-    RUN_TEST(
-        adxl345bGetMeasurementsForNMillisecondsReadCorrectValuesInStreamModeWithWrongSizedArray);
-    RUN_TEST(
-        adxl345bGetMeasurementsForNMillisecondsReadCorrectValuesInFifoModeWithCorrectSizedArray);
-    RUN_TEST(adxl345bGetMeasurementsForNMillisecondsReadCorrectValuesInFifoModeWithWrongSizedArray);
-    RUN_TEST(
-        adxl345bGetMeasurementsForNMillisecondsReadCorrectValuesInTriggerModeWithCorrectSizedArray);
-    RUN_TEST(
-        adxl345bGetMeasurementsForNMillisecondsReadCorrectValuesInTriggerModeWithWrongSizedArray);
-
-    RUN_TEST(adxl345bConvertDataXYZCorrectValue);
-
+    RUN_TEST(adxl345bConvertDataXYZCorrectValueWithFullResON);
+    RUN_TEST(adxl345bConvertDataXYZCorrectValueWithFullResOFF);
     return UNITY_END();
 }

--- a/test/unit/dummies/hal/i2c/I2c.c
+++ b/test/unit/dummies/hal/i2c/I2c.c
@@ -148,9 +148,7 @@ i2cErrorCode_t i2cUnittestReadCommandPassForAdxl345bInBypassMode(uint8_t *readBu
 
     /* generate sample data without any real world connection to test
      * implementation */
-    for (uint8_t index = 0; index < sizeOfReadBuffer; index++) {
-        readBuffer[index] = byteZero;
-    }
+    i2cUnittestWriteByteMultipleTimes(readBuffer, sizeOfReadBuffer, byteZero);
 
     return 0x00;
 }
@@ -183,7 +181,7 @@ i2cErrorCode_t i2cUnittestReadCommandPassForAdxl345bInFifoMode(uint8_t *readBuff
                         0b00011111; // set FiFo Mode, Watermark and samples for Trigger
         return 0x00;
     }
-    i2cUnittestWriteByteMultipleTimes(readBuffer, sizeOfReadBuffer, byteTwo);
+    i2cUnittestWriteByteMultipleTimes(readBuffer, sizeOfReadBuffer, byteZero);
     return 0x00;
 }
 i2cErrorCode_t i2cUnittestReadCommandPassForAdxl345bInTriggerMode(uint8_t *readBuffer,
@@ -198,7 +196,30 @@ i2cErrorCode_t i2cUnittestReadCommandPassForAdxl345bInTriggerMode(uint8_t *readB
                         0b00011111; // set Trigger Mode, Watermark and samples for Trigger
         return 0x00;
     }
-    i2cUnittestWriteByteMultipleTimes(readBuffer, sizeOfReadBuffer, byteThree);
+    i2cUnittestWriteByteMultipleTimes(readBuffer, sizeOfReadBuffer, byteZero);
+    return 0x00;
+}
+
+i2cErrorCode_t i2cUnittestReadCommandPassForAdxl345bWithFullResOFF(uint8_t *readBuffer,
+                                                                   uint8_t sizeOfReadBuffer,
+                                                                   uint8_t slaveAddress,
+                                                                   i2c_inst_t *i2cHost) {
+
+    /* generate sample data without any real world connection to test
+     * implementation */
+    i2cUnittestWriteByteMultipleTimes(readBuffer, sizeOfReadBuffer, dataFormatFullResOFF);
+
+    return 0x00;
+}
+i2cErrorCode_t i2cUnittestReadCommandPassForAdxl345bWithFullResON(uint8_t *readBuffer,
+                                                                  uint8_t sizeOfReadBuffer,
+                                                                  uint8_t slaveAddress,
+                                                                  i2c_inst_t *i2cHost) {
+
+    /* generate sample data without any real world connection to test
+     * implementation */
+    i2cUnittestWriteByteMultipleTimes(readBuffer, sizeOfReadBuffer, dataFormatFullResON);
+
     return 0x00;
 }
 

--- a/test/unit/dummies/hal/i2c/include/I2cUnitTest.h
+++ b/test/unit/dummies/hal/i2c/include/I2cUnitTest.h
@@ -1,15 +1,15 @@
 #ifndef ENV5_I2C_UNITTEST_HEADER
 #define ENV5_I2C_UNITTEST_HEADER
 
-#include "eai/hal/I2cTypedefs.h"
-#include <stdint.h>
+#include "eai/hal/I2c.h"
 
 /* region VARIABLES */
 
 static const uint8_t byteZero = 0xBE;
 static const uint8_t byteOne = 0xEF;
-static const uint8_t byteTwo = 0x55;
-static const uint8_t byteThree = 0xA7;
+static const uint8_t dataFormatFullResON = byteZero;
+static const uint8_t dataFormatFullResOFF = byteZero & 11110111;
+
 static const uint8_t correctByteChecksum = 0x92;
 static const uint8_t wrongByteChecksum = 0x00;
 
@@ -78,6 +78,16 @@ i2cErrorCode_t i2cUnittestReadCommandPassForAdxl345bInTriggerMode(uint8_t *readB
                                                                   uint8_t sizeOfReadBuffer,
                                                                   uint8_t slaveAddress,
                                                                   i2c_inst_t *i2cHost);
+
+i2cErrorCode_t i2cUnittestReadCommandPassForAdxl345bWithFullResON(uint8_t *readBuffer,
+                                                                  uint8_t sizeOfReadBuffer,
+                                                                  uint8_t slaveAddress,
+                                                                  i2c_inst_t *i2cHost);
+
+i2cErrorCode_t i2cUnittestReadCommandPassForAdxl345bWithFullResOFF(uint8_t *readBuffer,
+                                                                   uint8_t sizeOfReadBuffer,
+                                                                   uint8_t slaveAddress,
+                                                                   i2c_inst_t *i2cHost);
 
 /* endregion ReadCommandPassForAdxl345b */
 i2cErrorCode_t i2cUnittestReadCommandPassForPac193x(uint8_t *readBuffer, uint8_t sizeOfReadBuffer,


### PR DESCRIPTION
BREAKING-CHANGE:
- Measuring Functions now require RawData array which replaces uint8_t array and reduces many calculations
- GetMeasurementsForNMilliseconds changed to GetMeasurementsForNMicroseconds

closes #405 