### PR TITLE
feat(spi): add alternative SPI implementation

### DIFF
--- a/src/hal/spi/CMakeLists.txt
+++ b/src/hal/spi/CMakeLists.txt
@@ -13,3 +13,25 @@ else()
   add_library(Spi INTERFACE)
   target_include_directories(Spi INTERFACE include)
 endif()
+
+add_library(SpiHal2 INTERFACE)
+target_include_directories(SpiHal2 INTERFACE include)
+
+
+if (_BUILDING_FOR_HARDWARE)
+  add_library(SpiPico OBJECT)
+
+  target_sources(SpiPico PRIVATE
+    SpiPico.c
+  )
+  target_link_libraries(SpiPico PRIVATE SpiHal2)
+
+  target_include_directories(SpiPico PRIVATE ${CMAKE_CURRENT_LIST_DIR}/picoImpl)
+  target_link_libraries(
+    SpiPico
+    PRIVATE Gpio Pico::hardware_spi Pico::pico_runtime
+  )
+  target_link_libraries(SpiPico INTERFACE
+    SpiHal2
+  )
+endif()

--- a/src/hal/spi/SpiPico.c
+++ b/src/hal/spi/SpiPico.c
@@ -1,0 +1,115 @@
+#include "eai/hal2/SpiPico.h"
+#include "hardware/spi.h"
+
+#include <stdlib.h>
+
+#include "eai/hal/Gpio.h"
+
+typedef struct PicoSpi {
+    Spi parent;
+    spi_inst_t *spi;
+    const SpiConfig *config;
+} PicoSpi;
+
+static PicoSpi *cast(Spi *self) {
+    return (PicoSpi *)self;
+}
+
+static void setConfig(Spi *self, const SpiConfig *config) {
+    PicoSpi *this = cast(self);
+    this->config = config;
+}
+
+static inline uint8_t eai_to_pico_cpol(uint8_t cpol) {
+    switch (cpol) {
+    case EAI_SPI_CPOL_0:
+        return SPI_CPOL_0;
+    default:
+        return SPI_CPOL_1;
+    }
+}
+
+static inline uint8_t eai_to_pico_cpha(uint8_t cpha) {
+    switch (cpha) {
+    case EAI_SPI_CPHA_0:
+        return SPI_CPHA_0;
+    default:
+        return SPI_CPHA_1;
+    }
+}
+
+static inline uint8_t eai_to_pico_data_order(uint8_t data_order) {
+    return SPI_MSB_FIRST;
+}
+
+static void init(Spi *self) {
+    PicoSpi *this = cast(self);
+    spi_init(this->spi, this->config->baudrate);
+    uint8_t pico_cpol = eai_to_pico_cpol(this->config->polarity);
+    uint8_t pico_cpha = eai_to_pico_cpha(this->config->phase);
+    uint8_t pico_order = eai_to_pico_data_order(this->config->order);
+    spi_set_format(this->spi, this->config->data_bits, pico_cpol, pico_cpha, pico_order);
+    gpioSetPinFunction(this->config->sckPin, GPIO_FUNCTION_SPI);
+    gpioSetPinFunction(this->config->mosiPin, GPIO_FUNCTION_SPI);
+    gpioSetPinFunction(this->config->misoPin, GPIO_FUNCTION_SPI);
+}
+
+static void deinit(Spi *self) {
+    PicoSpi *this = cast(self);
+    spi_deinit(this->spi);
+
+    gpioSetPinFunction(this->config->sckPin, GPIO_FUNCTION_NULL);
+    gpioSetPinFunction(this->config->mosiPin, GPIO_FUNCTION_NULL);
+    gpioSetPinFunction(this->config->misoPin, GPIO_FUNCTION_NULL);
+
+    gpioDisablePin(this->config->sckPin);
+    gpioDisablePin(this->config->mosiPin);
+    gpioDisablePin(this->config->misoPin);
+}
+
+static void select(Spi *self, uint8_t slaveHandle) {
+    gpioSetPin(slaveHandle, GPIO_PIN_LOW);
+}
+
+static void deselect(Spi *self, uint8_t slaveHandle) {
+    gpioSetPin(slaveHandle, GPIO_PIN_HIGH);
+}
+
+static void setupSlave(Spi *self, uint8_t slaveHandle) {
+    gpioSetPinFunction(slaveHandle, GPIO_FUNCTION_SPI);
+    gpioInitPin(slaveHandle, GPIO_OUTPUT);
+    deselect(self, slaveHandle);
+}
+
+static void write(Spi *self, const uint8_t *data, uint32_t length) {
+    PicoSpi *this = cast(self);
+    spi_write_blocking(this->spi, data, length);
+}
+
+static void read(Spi *self, uint8_t *data, uint32_t length) {
+    PicoSpi *this = cast(self);
+    spi_read_blocking(this->spi, 0, data, length);
+}
+
+static void destroy(Spi **self) {
+    free(*self);
+    *self = NULL;
+}
+
+Spi *PicoSpi_create(struct spi_inst *pico_instance) {
+    static SpiFns fns = {
+        .init = init,
+        .deinit = deinit,
+        .select = select,
+        .deselect = deselect,
+        .setupSlave = setupSlave,
+        .write = write,
+        .read = read,
+        .destroy = destroy,
+        .setConfig = setConfig,
+    };
+    PicoSpi *spi = malloc(sizeof(PicoSpi));
+    spi->spi = pico_instance;
+    spi->parent.fns = &fns;
+    return (Spi *)spi;
+}

--- a/src/hal/spi/include/eai/hal2/Spi.h
+++ b/src/hal/spi/include/eai/hal2/Spi.h
@@ -1,0 +1,80 @@
+#ifndef SPI_H
+#define SPI_H
+#include <stdint.h>
+
+typedef struct Spi Spi;
+
+typedef enum {
+    EAI_SPI_CPOL_0 = 0,
+    EAI_SPI_CPOL_1 = 1,
+} SpiClockPolarity;
+
+typedef enum {
+    EAI_SPI_CPHA_0 = 0,
+    EAI_SPI_CPHA_1 = 1,
+} SpiClockPhase;
+
+typedef enum {
+    EAI_SPI_MSB_FIRST = 0,
+    EAI_SPI_LSB_FIRST = 1,
+} SpiOrder;
+
+typedef struct SpiConfig {
+    uint8_t sckPin;
+    uint8_t misoPin;
+    uint8_t mosiPin;
+    uint32_t baudrate;
+    uint8_t polarity;
+    uint8_t phase;
+    uint8_t data_bits;
+    uint8_t order;
+} SpiConfig;
+
+typedef struct SpiFns {
+    void (*init)(Spi *self);
+    void (*deinit)(Spi *self);
+    void (*setConfig)(Spi *self, const SpiConfig *config);
+    void (*setupSlave)(Spi *self, uint8_t slaveHandle);
+    void (*select)(Spi *self, uint8_t slaveHandle);
+    void (*deselect)(Spi *self, uint8_t slaveHandle);
+    void (*read)(Spi *self, uint8_t *data, uint32_t len);
+    void (*write)(Spi *self, const uint8_t *data, uint32_t len);
+    void (*destroy)(Spi **self);
+} SpiFns;
+
+struct Spi {
+    const SpiFns *fns;
+};
+
+static inline void Spi_setConfig(Spi *self, const SpiConfig *config) {
+    self->fns->setConfig(self, config);
+}
+
+static inline void Spi_init(Spi *self) {
+    self->fns->init(self);
+}
+
+static inline void Spi_deinit(Spi *self) {
+    self->fns->deinit(self);
+}
+
+static inline void Spi_read(Spi *self, uint8_t *data, uint32_t len) {
+    self->fns->read(self, data, len);
+}
+
+static inline void Spi_write(Spi *self, const uint8_t *data, uint32_t len) {
+    self->fns->write(self, data, len);
+}
+
+static inline void Spi_select(Spi *self, uint8_t slaveHandle) {
+    self->fns->select(self, slaveHandle);
+}
+
+static inline void Spi_deselect(Spi *self, uint8_t slaveHandle) {
+    self->fns->deselect(self, slaveHandle);
+}
+
+static inline void Spi_setupSlave(Spi *self, uint8_t slaveHandle) {
+    self->fns->setupSlave(self, slaveHandle);
+}
+#endif // SPI_H

--- a/src/hal/spi/picoImpl/eai/hal2/SpiPico.h
+++ b/src/hal/spi/picoImpl/eai/hal2/SpiPico.h
@@ -1,0 +1,12 @@
+#ifndef SPIPICO_H
+#define SPIPICO_H
+
+#include "eai/hal2/Spi.h"
+
+typedef struct spi_inst spi_inst_t;
+
+/*
+ * supports only MSB_FIRST for order!
+ */
+Spi *PicoSpi_create(struct spi_inst *);
+#endif // SPIPICO_H


### PR DESCRIPTION
This new implementation allows for easier setup and provides an interface that is completely independent from pico sdk.
Users only need to call `PicoSpi_create` and obtain an ADT that will handle all subsequent spi interaction.
Configuration of the spi interface is handled separately and not during instantiation.
This way configuration remains independent of the pico sdk as well.